### PR TITLE
[WIP] VirtualBox v6 support

### DIFF
--- a/lib/VBoxProvider.js
+++ b/lib/VBoxProvider.js
@@ -19,6 +19,24 @@ const isPortAvailable = require('is-port-available');
 
 class VBoxProvider {
 
+    // Returns the major version of the VirtualBox instance
+    async majorVersion() {
+      let version = await execute("--version", "", false);
+
+      return Number(version.split('.')[0]);
+    }
+
+    // Returns the correct serial port settings based on version.
+    async serialOut(name) {
+      let version = await this.majorVersion();
+
+      if (version < 6) { return 'disconnected'; }
+
+      let logPath = path.join(os.homedir(),'.baker',`${name}.log`);
+
+      return `file ${logPath}`;
+    }
+
     /**
      * Get default run command.
      *
@@ -44,7 +62,8 @@ class VBoxProvider {
         await execute("storagectl", `"${name}" --name IDE --add ide`, verbose);
         await execute("storageattach", `${name} --storagectl IDE --port 0 --device 0 --type dvddrive --medium "${iso}"`, verbose);
 
-        await execute("modifyvm", `${name}  --uart1 0x3f8 4 --uartmode1 disconnected`, verbose);
+        let serial = await this.serialOut(name);
+        await execute("modifyvm", `${name}  --uart1 0x3f8 4 --uartmode1 ${serial}`, verbose);
         
         // NIC1 =======
         await execute("modifyvm", `${name} --nic1 nat`, verbose);
@@ -93,7 +112,7 @@ class VBoxProvider {
             let sshConfig = {port: ssh_port, user: 'root', private_key: sshKeyPath};
             //let cmd = 'echo -e "o\nn\np\n1\n\n\nw" | fdisk /dev/sda && /sbin/mkfs.ext4 /dev/sda1';
             let cmd = `/sbin/mkfs.ext4 /dev/sda; mount -t ext4 /dev/sda /mnt/disk`;
-            console.log('Formating virtual drive');
+            console.log('Formatting virtual drive');
 
             await util.sshExec(cmd, sshConfig, 60000, verbose).catch( e => {console.log(e)});;
         }
@@ -101,7 +120,8 @@ class VBoxProvider {
 
     async customize(name, ip, ssh_port, forward_ports=[], syncs, verbose) {
         // modifyvm ${VM} --uart1 0x3f8 4 --uartmode1 disconnected
-        await execute("modifyvm", `${name}  --uart1 0x3f8 4 --uartmode1 disconnected`, verbose);
+        let serial = await this.serialOut(name);
+        await execute("modifyvm", `${name}  --uart1 0x3f8 4 --uartmode1 ${serial}`, verbose);
         
         // syncs
         if( syncs.length > 0 )


### PR DESCRIPTION
Looks like the issue with v6 is that cloud-init (which requires a serial port to function) can't write to the disconnected serial port, and hangs indefinitely (not sure why this changed between v5 and v6). Setting the port to write out to a file appears to fix this.

I had timeout issues with the VM not coming up soon enough for the SSH when I set the serial port to a file for v5, but v5 already works fine with the disconnected serial, so maybe a version check is clean enough.

Tested working on:
- ArchLinux w/ virtualbox 6.0.4
- Ubuntu 18.04 w/ virtualbox 6.0.4
- Ubuntu 18.04 w/ virtualbox 5.2.18